### PR TITLE
PB-697-rails-image-attribute use public docker image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,4 @@
+image: "sorchaabel/ruby-pipeline-example:1.0"
 steps:
   - name: ":rspec:"
     command: "scripts/ci/setup.sh && scripts/ci/parallel_specs.sh"


### PR DESCRIPTION
Use new step `image` attribute to use docker hub image
For complete e2e it's using an image i posted to dockerhub
I'll circle back in a few days and update this to use a buildkite official image.